### PR TITLE
Fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Download the resources:
 
 ```sh
 $ curl https://raw.githubusercontent.com/pb82/serverless-operator/master/deploy/operator.yaml > operator.yaml
-$ curl https://raw.githubusercontent.com/pb82/serverless-operator/master/deploy/rbac.yaml > rbay.yaml
+$ curl https://raw.githubusercontent.com/pb82/serverless-operator/master/deploy/rbac.yaml > rbac.yaml
 $ curl https://raw.githubusercontent.com/pb82/serverless-operator/master/deploy/crd.yaml > crd.yaml
 ```
 


### PR DESCRIPTION
Was seeing this error in operator logs

```
ERROR: logging before flag.Parse: E0813 12:54:47.684063       1 reflector.go:205] github.com/pb82/serverless-operator/vendor/github.com/operator-framework/operator-sdk/pkg/sdk/informer.go:84: Failed to list *unstructured.Unstructured: serverlessactions.serverless.pb82.com is forbidden: User "system:serviceaccount:openwhisk:default" cannot list serverlessactions.serverless.pb82.com in the namespace "openwhisk": User "system:serviceaccount:openwhisk:default" cannot list serverlessactions.serverless.pb82.com in project "openwhisk"
```